### PR TITLE
spell-check "personal" front-end strings

### DIFF
--- a/Console/Command/Crypt.php
+++ b/Console/Command/Crypt.php
@@ -98,7 +98,7 @@ class Crypt extends \Symfony\Component\Console\Command\Command
     protected function configure()
     {
         $this->setName("gdpr:crypt");
-        $this->setDescription("Crypt all personnal data");
+        $this->setDescription("Crypt all personal data");
         $this->setDefinition([
         ]);
         parent::configure();

--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -55,7 +55,7 @@ class InstallData implements InstallDataInterface
      * @var array
      */
     protected $customerFields = [
-        'personnalized_suggestions' => 'Personnalized suggestions',
+        'personnalized_suggestions' => 'Personalized suggestions',
         'third_party' => 'Third party',
     ];
 

--- a/view/frontend/templates/gdpr/account/optin.phtml
+++ b/view/frontend/templates/gdpr/account/optin.phtml
@@ -6,12 +6,12 @@
  */
 if ( $this->displayPersonnalizedSuggestions() ) { ?>
 <div id="gdpr-personnalized-suggestions-box" class="field choice gdpr">
-    <input type="checkbox" name="personnalized_suggestions" class="checkbox" id="account-form-personnalized-suggestions" class="input-text" data-validate="{required:false}" value="1" title="<?php /* @escapeNotVerified */ echo __('Accept user personnalization') ?>" <?php if ( $this->getPersonnalizedSuggestions() ) { ?>checked="checked" <?php } ?>/>
-    <label for="account-form-personnalized-suggestions" class="label"><span><?php /* @escapeNotVerified */ echo __('Accept user personnalization') ?></span></label>
+    <input type="checkbox" name="personnalized_suggestions" class="checkbox" id="account-form-personnalized-suggestions" class="input-text" data-validate="{required:false}" value="1" title="<?php /* @escapeNotVerified */ echo __('Accept user personalization') ?>" <?php if ( $this->getPersonnalizedSuggestions() ) { ?>checked="checked" <?php } ?>/>
+    <label for="account-form-personnalized-suggestions" class="label"><span><?php /* @escapeNotVerified */ echo __('Accept user personalization') ?></span></label>
     <span class="tooltip wrapper">
         <a class="link tooltip toggle" href="#"><?php /* @escapeNotVerified */ echo __('What\'s this?') ?></a>
         <span class="tooltip content">
-            <?php echo /* @escapeNotVerified */ __('Check this to access personnalized search result and suggestions based on your own history.')?>
+            <?php echo /* @escapeNotVerified */ __('Check this to access personalized search result and suggestions based on your own history.')?>
         </span>
     </span>
 </div>

--- a/view/frontend/templates/gdpr/account/settings.phtml
+++ b/view/frontend/templates/gdpr/account/settings.phtml
@@ -13,7 +13,7 @@
 <?php }
 if ( $this->displayExport() ) { ?>
 <div class="block block-dashboard-info">
-    <div class="block-title"><strong><?php /* @escapeNotVerified */ echo __('Export your personnal data') ?></strong></div>
+    <div class="block-title"><strong><?php /* @escapeNotVerified */ echo __('Export your personal data') ?></strong></div>
     <div class="block-content">
         <div class="box-actions">
             <a class="action edit" href="<?php echo $this->getUrl('privacy/export/') ?>">


### PR DESCRIPTION
In English, such words as "personal" and "personalize" have only a single `n`, but in almost every use of such terms in this extension, the `n` is doubled; it looks unprofessional on the front end, so I have corrected the spellings of those strings.

I would correct every "ersonna" to "ersona" in the entire code-base, but I wanted to disrupt it as little as necessary, and for database keys in particular, a name change will be disruptive to the end user.